### PR TITLE
chore(docs): drop the context-system bundle reference

### DIFF
--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,12 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [chore] context-system skill installed system-wide; bundle purged from the repo
+- **Date:** 2026-07-10
+- **Area:** infra / docs
+- **What:** `docs/context-system.skill` (a 26KB zip: `SKILL.md` + `references/` + 10 `assets/*.template.md`) is no longer tracked. Extracted and installed system-wide to `~/.claude/skills/context-system/` (16/16 files; every internal `references/` + `assets/` path verified to resolve). Purged the blob from **all git history** via `git-filter-repo --path docs/context-system.skill --invert-paths` + force-push (`main` c7c4d27 → 57b650c, 32 commits rewritten). Branch protection was temporarily set `allow_force_pushes=true` for the push and **restored to `false`** immediately after. Removed the dead `docs/README.md` row and its stale "these docs live only on this machine" note.
+- **Notes:** ⚠️ **The purge is incomplete on GitHub's side, and cannot be completed from the CLI.** The bundle is still fetchable at `raw.githubusercontent.com/Chineme123/quiz-app/2e67e5f…/docs/context-system.skill` (verified HTTP 200) because `refs/pull/16..20/head` each have the old commit `2e67e5f` as an ancestor. GitHub never deletes `refs/pull/*` and the repo owner cannot delete them, so **garbage collection will not free the blob**. Only two full fixes exist: (a) GitHub Support purges the unreachable objects, or (b) delete + recreate the repo (0 stars, 0 forks — but PRs #15–#20 and their discussion are lost). Same limitation applied to the earlier secrets purge. Not treated as urgent: this is the developer's own skill, not a credential. A mirror backup was taken before rewriting. **Old commit SHAs are now dead** — SHAs cited in PRs #15–#20 and in earlier progress entries refer to rewritten commits.
+
 ### [docs] Spec 0001 — frontend foundation + the auth session it depends on
 - **Date:** 2026-07-10
 - **Area:** context / docs / (designs: frontend + backend auth)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,9 +20,9 @@ For the *distilled, current* decisions, read `../context/foundation.md` — it's
 | `uc14-create-user-profile.md` | UC14 full design |
 | `uc14-ui-ux-brief.md` | UC14 UI/UX design brief |
 | `diagrams/` | `.drawio` diagrams (microservice architecture + general) |
-| `context-system.skill` | The context-system skill bundle (the tool that built `context/`) |
+| `specs/` | Build specs (`/architect` output). `0001-frontend-foundation/` is the frontend + auth-session decision |
 
 ## Status vs. code
 Built: UC6, UC8, UC14. In v1 scope but undesigned/broken: UC2 (create classroom), UC3 (join). Deferred: UC4/5/7/9–13/15–19. See `../context/build-graph.md` and `../context/foundation.md` §8.
 
-> Note (`foundation.md` §11): these docs live only on this machine by the developer's deliberate local-only choice — an accepted tradeoff, not an oversight.
+> The `context-system` skill bundle that built `context/` used to live here as `context-system.skill`. It is now installed system-wide at `~/.claude/skills/context-system/` and is no longer tracked in this repo.


### PR DESCRIPTION
The `context-system` skill bundle is now installed system-wide at `~/.claude/skills/context-system/` and is no longer tracked in this repo.

## What happened

- Extracted `docs/context-system.skill` (26KB zip: `SKILL.md` + `references/` + 10 `assets/*.template.md`) and installed all 16 files system-wide. Verified every internal `references/` and `assets/` path resolves.
- Purged the blob from **all git history** with `git-filter-repo --path docs/context-system.skill --invert-paths`, then force-pushed. `main` went `c7c4d27` → `57b650c`, 32 commits rewritten.
- Branch protection was temporarily set `allow_force_pushes=true` for the push and **restored to `false`** immediately.

This PR only cleans up what the rewrite left behind: the dead `docs/README.md` row, and a stale note claiming these docs live only on one machine (untrue since the repo went public).

## ⚠️ The purge is incomplete, and can't be finished from the CLI

The bundle is **still fetchable** at `raw.githubusercontent.com/.../2e67e5f.../docs/context-system.skill` (verified HTTP 200). Cause: `refs/pull/16/head` … `refs/pull/20/head` each have the old commit `2e67e5f` as an ancestor. GitHub never deletes `refs/pull/*`, and a repo owner cannot delete them — so **garbage collection will not free the blob**.

Two options remain, both outside git:
1. Ask GitHub Support to purge unreachable objects.
2. Delete and recreate the repo (0 stars, 0 forks — but PRs #15–#20 are lost).

Not urgent: this is the developer's own skill, not a credential. Recorded in `progress-log.md`.

**Old commit SHAs are dead.** SHAs cited in PRs #15–#20 now point at rewritten commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)