### PR TITLE
docs(context): record context-first, skills-on-demand convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,9 @@ Read this first, every session. Then read the context system — `README.md` has
 
 This is a **solo project** (foundation §0). There is no team collaboration layer (no `COLLAB.md`, no branch/PR ceremony required). The discipline below is what keeps the context system honest anyway.
 
+## Tooling — context-first, skills on demand
+The **context system is the single source of truth**: `foundation.md`, the other `context/*.md`, this file, and `progress-log.md`. This repo deliberately does **not** adopt the skills toolchain's file convention — do **not** create `AGENTS.md`, `docs/scope/`, or `docs/reviews/`. Skills (`/architect`, `/develop`, `/verify`, `/test`, `/check`, …) are invoked **on demand** and read the `context/` files, never `AGENTS.md`. The one already wired in is `/architect`, which writes `docs/specs/` — and `foundation.md` cites those specs. When you work, route through the relevant `context/` files and **cite them as you go**, so the use of the system is visible rather than implicit.
+
 ## Before you write any code
 1. Read `context/code-standards.md` top to bottom — it's the implementation law.
 2. Read the context file(s) relevant to the work (`architecture.md` for shape, `library-docs.md` before adding a dependency, `security.md` before touching student data or the LLM).

--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,12 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [decision] Context system stays canonical; skills invoked on demand, not bridged
+- **Date:** 2026-07-10
+- **Area:** context / docs
+- **What:** Weighed combining the home-grown context system with the Claude skills toolchain (`/develop`, `/check`, `/sync`, `/scope` — which key off `AGENTS.md` + `docs/scope/` + `docs/reviews/`). Chose **context-first, skills on demand**: `context/` (with `foundation.md` as source of truth) + `CLAUDE.md` + `progress-log.md` remain the single canonical system. The skills' file convention is **not** adopted — no `AGENTS.md`, `docs/scope/`, or `docs/reviews/` will be created. Skills are invoked à la carte and fed the `context/` files; `/architect` (which already writes `docs/specs/`, cited by `foundation.md`) is the one existing touchpoint. Recorded the convention in `CLAUDE.md` ("Tooling — context-first, skills on demand").
+- **Notes:** Rationale — two overlapping conventions for the same job; `AGENTS.md` would duplicate `context/architecture.md` + `code-standards.md`. Behavioural commitment: route each task through the relevant `context/` files and **cite them** as work proceeds, so use of the system is visible rather than implicit. On-disk confirmation: no `AGENTS.md`, no `docs/scope/`, no `docs/reviews/` exist — deliberately.
+
 ### [docs] Reconcile `ui-registry.md` with the built foundation primitives
 - **Date:** 2026-07-10
 - **Area:** context / docs


### PR DESCRIPTION
Records the decision to keep the context system canonical and invoke skills on demand, rather than adopting the toolchain's `AGENTS.md` / `docs/scope/` / `docs/reviews/` convention.

- **`CLAUDE.md`** — new "Tooling — context-first, skills on demand" section (the enforcement layer read every session).
- **`context/progress-log.md`** — a `[decision]` entry with the rationale.

No code changes. `context/` (`foundation.md` as source of truth) + `CLAUDE.md` + `progress-log.md` remain the single source of truth; `/architect` → `docs/specs/` stays the one wired-in skill touchpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)