### PR TITLE
docs: reconcile stale platform docs + run-doc (spec 0002 phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ A classroom quiz web app — teachers author and publish quizzes inside classroo
 
 ---
 
+## Getting started
+
+**Prerequisites:** Docker Desktop, the **.NET 10 SDK** (for host-run migrations and `dotnet test`), and **Node 20** (for the web app).
+
+```bash
+# 1. Secrets: copy the template, then set a JWT signing key + a Postgres password
+cp .env.example .env
+
+# 2. Bring up Postgres + the backend services (one command)
+docker compose up
+
+# 3. Run the web app with hot reload (proxies /api to the gateway)
+cd frontend && npm ci && npm run dev
+```
+
+The **YARP gateway** is the single origin: it serves the web app and forwards `/api/*` to the right service, so the in-memory access token + `HttpOnly` refresh cookie work same-origin. The containerised local flow and the gateway are settled by [`docs/specs/0002-production-platform/`](docs/specs/0002-production-platform/index.md); its [`verify.md`](docs/specs/0002-production-platform/verify.md) carries the migration and test commands. Backend build/test from the repo root: `dotnet build QuizApp.sln` and `dotnet test`.
+
+---
+
 ## The context system (read this before writing any code)
 
 This repo is driven by a **context system**: a set of source-of-truth markdown files an AI coding agent (and you) read before touching code, so decisions stay consistent across sessions and don't drift. **`context/foundation.md` is the source of truth**; every other file references it and none restate it.
@@ -54,4 +73,4 @@ When a decision changes, update `foundation.md` **first**, then ripple the chang
 - **The AI loop must degrade, not break.** Every Claude call has a deterministic fallback.
 
 ## Status
-Foundation converged (v3); the full context system is written, and the **UI trio is generated** from the Claude Design export (`design-system/`) — nothing PENDING. Repo is **public** with CI + PR/auto-merge. Layer-0 backend is underway (framework pin, live Postgres migration, and secrets rotation done; identity/auth + scoring redesign remain). The frontend (`frontend/`) isn't scaffolded yet. See `context/progress-log.md` for the running state.
+Foundation converged (v3); the context system is written, and the **UI trio is generated** from the Claude Design export (`design-system/`). Repo is **public** with CI + branch protection + auto-merge. **Layer-0 is complete** (framework pin, PostgreSQL migration, real scoring, identity/auth). The **frontend is built** — spec 0001 (auth + Manage Profile screens, 30 tests). Now in progress: the **production platform** — spec 0002 (YARP gateway, containerised local dev, expanded CI, deploy to Railway). See `context/progress-log.md` for the running state.

--- a/add_docker.sh
+++ b/add_docker.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# ⚠️ ARCHIVAL — superseded one-shot generator. It emitted .NET 8 Dockerfiles; the committed
+# service Dockerfiles are already multi-stage .NET 10, and the gateway image is added in spec 0002.
+# Do NOT re-run this; the canonical Dockerfiles live beside each *.API. Kept for history.
+
 SERVICES=("Auth" "User" "Quiz" "Result" "Notification")
 
 for SERVICE in "${SERVICES[@]}"; do

--- a/context/build-graph.md
+++ b/context/build-graph.md
@@ -6,13 +6,14 @@
 This is a map of *what-requires-what* — **NOT a timeline, a build plan, or a prescribed order**. The developer builds breadth-first with Claude (foundation §0), picking their own path; this file just says what a node genuinely needs before it can work. **Hard requirement** = cannot build/run without it. **Soft benefit** = easier or nicer with it, possible without.
 
 ## Layer 0 — foundational prerequisites (nearly everything needs these)
-These are the must-fixes from `foundation.md` §8. Until they're in, features built on top are building on sand.
-- **`global.json` + framework pin** to .NET 10; reconcile every `.csproj` (fix the duplicated-header one).
-- **PostgreSQL up** via `docker-compose` (swap the `mssql` image for `postgres`), connection strings in config/secrets.
-- **Regenerated EF migration** against Postgres, including the attempt-side tables (QuizAttempt/QuizAnswer/Enrollment/ProcessedCommand). *Nothing that touches the DB runs without this — step one.*
-- **Canonical identity plumbing**: `Guid UserId` from the JWT `NameIdentifier` claim, everywhere; remove hardcoded IDs.
-- **Minimal AuthService** issuing HS256 JWTs; shared issuer/audience/key from secrets.
-- **API gateway (YARP) + CORS** as the single frontend origin.
+> ✅ **Layer-0 is complete** (see `progress-log.md`, 2026-07-10) — the items below are built. Kept as the dependency map: features still *require* these, they are just no longer pending.
+These were the must-fixes from `foundation.md` §8.
+- ✅ **`global.json` + framework pin** to .NET 10; every `.csproj` reconciled (duplicated-header one fixed).
+- ✅ **PostgreSQL up** via `docker compose` (runs `postgres:17`; the `mssql`→`postgres` swap is done), connection strings in config/secrets.
+- ✅ **Regenerated EF migration** against Postgres, including the attempt-side tables (QuizAttempt/QuizAnswer/Enrollment/ProcessedCommand).
+- ✅ **Canonical identity plumbing**: `Guid UserId` from the JWT `NameIdentifier` claim, everywhere; hardcoded IDs removed.
+- ✅ **Minimal AuthService** issuing HS256 JWTs; shared issuer/audience/key from secrets.
+- 🟡 **API gateway (YARP)** as the single frontend origin (no CORS — same-origin, §7 #27). Spec 0002; a production concern, so the Vite proxy is the dev single-origin today.
 
 ## The keystone unlock
 The **create→take→results→feedback loop**. It's unblocked in this order: **(1)** the Postgres migration → **(2)** the redesigned scoring contract (a strategy that can see correct answers) → **(3)** ResultService's graded-event projection. Once those three exist, the loop closes and everything else is elaboration.
@@ -35,7 +36,7 @@ The **create→take→results→feedback loop**. It's unblocked in this order: *
 
 ## External dependencies with lead time ⏳
 - **Claude API key** — provision before the AI paths can run live (the fallback lets you build without it).
-- **Railway project + managed Postgres** — provision before deploy; local Docker Postgres unblocks all dev.
+- **Railway project + managed Postgres** — provision before deploy (spec 0002 Phase 6). Docker Hub is reachable again, so local `docker compose` Postgres unblocks all dev.
 - **Claude Design export** — ⏳ **blocks the UI trio** (`ui-tokens`/`ui-rules`/`ui-registry`) and therefore the SPA's final styling. Start it early; the SPA's *logic* can be built against placeholder styling.
 
 ## The one genuine tension

--- a/context/foundation.md
+++ b/context/foundation.md
@@ -144,12 +144,13 @@ The heart of the file. Numbered so other files cite `foundation.md §7 #N`. Rows
 - **UC9** View My Results & Progress (student) — ResultService read. ⬜
 - **UC10** View Classroom Results (teacher) — ResultService read. ⬜
 - **UC14** Create/Update User Profile — role-aware. ✅ built (needs `Users`-row + partial-update fixes, §10).
-- **Minimal AuthService** issuing JWTs; end-to-end auth + `[Authorize]` enforcement. ⬜
-- **API gateway (YARP)** + CORS. ⬜
-- **React + Vite SPA** covering the loop screens. ⬜
+- **Minimal AuthService** issuing JWTs; end-to-end auth + `[Authorize]` enforcement. ✅ built (Layer-0).
+- **API gateway (YARP)** as the single origin. 🟡 in progress (spec 0002); CORS is deliberately absent (§7 #27, same-origin).
+- **React + Vite SPA** covering the loop screens. ✅ built — spec 0001 (auth + Manage Profile; dashboard slice next).
 
 ### Must-fix before/inside v1 (repairs the loop depends on — not new features; these are Layer 0)
-- ⚠️ **Migrate to Postgres + regenerate the EF migration** — drop the SQL Server migration, add Npgsql, generate a fresh `InitialCreate` against Postgres including *all* current entities (QuizAttempt/QuizAnswer/Enrollment/ProcessedCommand were missing). One action covers the provider switch and the stale-migration bug. **Step one.**
+> ✅ **All Layer-0 must-fixes are complete** (framework pin, PostgreSQL migration, real scoring, identity/auth) — see `progress-log.md` (2026-07-10). The bullets below are kept as the historical record of what Layer-0 covered.
+- ✅ **Migrated to Postgres + regenerated the EF migration** — dropped the SQL Server migration, added Npgsql, generated a fresh `InitialCreate` against Postgres including *all* current entities (QuizAttempt/QuizAnswer/Enrollment/ProcessedCommand, previously missing). One action covered the provider switch and the stale-migration bug.
 - ⚠️ **Redesign the scoring contract** so a strategy can see the correct answers (current `IScoringStrategy.Score(QuizAttempt)` structurally can't grade).
 - ⚠️ **Pin the framework** (`global.json`) and reconcile every `.csproj` to .NET 10 (§7 #13).
 - ⚠️ **Fix identity + auth** to §7 #14/#15 (remove hardcoded IDs, unify JWT audience, uncomment `[Authorize]`).
@@ -186,7 +187,7 @@ Honest "not scaling yet, and here's what replaces it":
 
 - **AI is stubbed today** — `StubLLMQuestionGenerationStrategy` returns canned placeholders; v1 replaces it with a real Claude call behind the existing strategy seams, **with a deterministic fallback** (§7 #6) so an outage degrades gracefully.
 - **Scoring is fake** — flat 10 pts for any non-empty answer, can't see correct answers; replaced by the redesigned scoring contract (§8 must-fix).
-- **Provider migration cost** — moving SQL Server → Postgres touches the migration (regenerated fresh), the `Options` mapping (`nvarchar`+JSON → `jsonb`), the concurrency token (`rowversion` → `xmin`), connection strings, and `docker-compose` (swap the `mssql` image for `postgres`). One-time v1 cost.
+- **Provider migration** ✅ done — the SQL Server → Postgres move touched the migration (regenerated fresh), the `Options` mapping (`nvarchar`+JSON → `jsonb`), the concurrency token (`rowversion` → `xmin`), connection strings, and `docker-compose` (`mssql` → `postgres`). One-time cost, paid.
 - **Graded-event dispatch is post-commit, no outbox** — can silently drop events on failure; acceptable for v1, replaced by an outbox when reliability matters.
 - **Committed secrets** — plaintext DB password + JWT signing key committed in code/appsettings → all move to secrets (§7 #15/#17, `security.md`).
 - **UserService FK gap** — Profile insert needs a `Users` row UserService never creates; first-time profile creation throws until a user is provisioned. Fix in v1.
@@ -197,7 +198,7 @@ Honest "not scaling yet, and here's what replaces it":
 
 ## §11 The deepest risk
 
-**The design-first brain lives on one machine — bus factor of one.** As of 2026-07-09 the design corpus has been **converted to markdown and consolidated in `docs/`** (originals archived in `quiz-trash/`), and this context system is in `context/` — so the AUM rationale, pattern choices, FR mappings, and UC catalog are now readable and in the repo tree rather than trapped in binary Word files. But the working tree is still **local-only and not pushed to any remote**, by the developer's deliberate choice — so the bus-factor risk (lose the machine, lose the project) is an **accepted tradeoff**, not an oversight. Re-evaluate if/when that changes.
+**The design-first brain lives in the repo — bus factor now low.** As of 2026-07-09 the design corpus was **converted to markdown and consolidated in `docs/`** (originals archived in `quiz-trash/`), and this context system is in `context/` — so the AUM rationale, pattern choices, FR mappings, and UC catalog are readable and in the repo tree rather than trapped in binary Word files. The working tree is now **pushed to a public GitHub remote with CI + branch protection** (§7 #32), so losing the machine no longer loses the project — the earlier local-only bus-factor risk is resolved. Only the `.env` secrets stay local (gitignored, by design).
 
 **Runner-up (now mitigated by design):** the product's wedge is AI, and AI is 100% stubbed. v1 makes it real (§7 #6) — and because a **deterministic fallback** is locked, a Claude outage degrades the experience instead of breaking the loop. The "AI" promise never blocks a working demo.
 

--- a/context/library-docs.md
+++ b/context/library-docs.md
@@ -9,16 +9,16 @@
 ### .NET 10 SDK — ✅
 - **Why:** foundation §7 #13 (finish the started upgrade; tooling already on 10). Pinned by a root `global.json`.
 - **How used:** every service + the gateway target `net10.0`, `Nullable` + `ImplicitUsings` enabled.
-- **Gotchas:** ⚠️ service `.csproj` files currently say `net8.0` and reference EF/JwtBearer `8.0.0`; bump all to 10.x. ⚠️ `QuizService.API.csproj` has duplicated `<Project>`/`<PropertyGroup>` headers — fix while bumping. Add `global.json` so the Codespace and any machine resolve the same SDK.
+- **Gotchas:** ✅ done — all `.csproj` target `net10.0` with EF/JwtBearer `10.x`, the duplicated `QuizService.API.csproj` headers are fixed, and a root `global.json` pins the SDK (`10.0.301`) so every machine resolves the same toolchain.
 
 ### EF Core 10 + Npgsql (`Npgsql.EntityFrameworkCore.PostgreSQL`) — ✅
 - **Why:** foundation §7 #10/#18 — PostgreSQL is Railway-native; Npgsql is the EF provider.
 - **How used:** database-per-service; `DbContext` per service (`QuizDbContext` is the model). TPH question inheritance via `HasDiscriminator` (`nameof` values); `MultipleChoiceQuestion.Options` stored as **`jsonb`** with an explicit `ValueComparer` for list change-tracking; optimistic concurrency via the Postgres **`xmin`** system column (`entity.UseXminAsConcurrencyToken()`); `EnableRetryOnFailure` in **every** service's `AddDbContext`.
-- **Gotchas:** ⚠️ current code uses `UseSqlServer`, `IsRowVersion()` (SQL Server `rowversion`), and `JsonSerializer`-to-`nvarchar` for Options — all change under Npgsql: `UseNpgsql`, drop `IsRowVersion` for `xmin`, and let Npgsql map the list to `jsonb`. ⚠️ **Regenerate migrations from scratch against Postgres** — the existing SQL Server migration is stale (missing the attempt-side tables) *and* provider-specific. This is the Layer-0 step-one (foundation §8). ⚠️ UserService currently has no `EnableRetryOnFailure` — add it. Keep the idempotency transaction inside the execution strategy (foundation §7 #19).
+- **Gotchas:** ✅ done — every service is on `UseNpgsql` with `xmin` concurrency and `jsonb` `Options`; the Postgres `InitialCreate` migrations were regenerated (attempt-side tables included) and applied; UserService gained `EnableRetryOnFailure`. Keep the idempotency transaction inside the execution strategy (foundation §7 #19).
 
 ### ASP.NET Core Web API — ✅
 - **How used:** five services + the gateway; thin controllers, Application services own logic (`code-standards.md` §4). Swagger per service in Development only.
-- **Gotchas:** the dev-time seeder runs from `Program.cs` in Development (`DataSeeder`) and calls `MigrateAsync()` — it will throw until the Postgres migration is regenerated.
+- **Gotchas:** the dev-time seeder (`DataSeeder`) runs from `Program.cs` in Development and calls `MigrateAsync()`; the Postgres migrations exist now, so it runs cleanly. ⚠️ spec 0002 pulls `MigrateAsync` out of the Development-only seeder into an env-gated startup hook (`RUN_MIGRATIONS_ON_STARTUP`), so production applies migrations without seeding demo data.
 
 ### Microsoft.AspNetCore.Authentication.JwtBearer — ✅
 - **Why:** foundation §7 #15 — HS256 JWTs, AuthService issues, all services validate.

--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,12 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [docs] Production platform Phase 1 — reconcile stale env/arch docs + add a run-doc
+- **Date:** 2026-07-13
+- **Area:** context / docs
+- **What:** Reworded the living stale platform claims to current and gave the repo a real entry point. `README.md`: new **Getting started** section (Docker Desktop + .NET 10 SDK + Node 20 → `cp .env.example .env` → `docker compose up` → `npm run dev`, citing spec 0002) and a corrected **Status** (Layer-0 done, frontend built per spec 0001, production platform in progress per 0002). `foundation.md`: §8 v1-scope marks fixed (AuthService ✅, SPA ✅ spec 0001, gateway 🟡 spec 0002) + a "Layer-0 complete" banner + the migrate-to-Postgres bullet flipped to done; §10 provider-migration cost → paid; §11 bus-factor note → repo is public + pushed with CI + branch protection. `library-docs.md`: dropped the `net8.0`/`UseSqlServer`/regenerate-migrations/Codespace gotchas (all done); noted spec 0002's env-gated migrate-on-startup. `build-graph.md`: Layer-0 marked complete, the `mssql`→`postgres` swap done, gateway + Railway pointed at spec 0002. Archival banners on `scaffold.sh`, `add_docker.sh`, and `docs/project-environment-and-architecture.md` (SQL Server + Codespaces, historical).
+- **Notes:** Phase 1 of spec 0002. Scope kept to the platform/env drift (SQL Server / Codespaces / local-Docker / gateway-pending / not-pushed) per **AC-13**; deliberately *not* a full UC-by-UC build-status audit. The README Getting started describes the target `docker compose` + gateway flow, which lands in Phases 2–3 of this same effort.
+
 ### [docs] Spec 0002 — production platform (gateway, Docker local dev, CI/CD, Railway) authored via /architect
 - **Date:** 2026-07-13
 - **Area:** context / docs

--- a/docs/project-environment-and-architecture.md
+++ b/docs/project-environment-and-architecture.md
@@ -1,6 +1,8 @@
 # Project Environment & Architecture
 
 > Converted from the original Word design doc (AUM corpus). Faithful extraction; original preserved in `quiz-trash/`.
+>
+> ⚠️ **ARCHIVAL — historical, do not follow for setup.** This describes the *original* environment (SQL Server 2022 + GitHub Codespaces), both since replaced (PostgreSQL; local Docker on macOS, no Codespaces). For how to run the project today, see the root `README.md` → **Getting started** and `docs/specs/0002-production-platform/`.
 
 ### 🛠 Project Environment & Architecture
 

--- a/scaffold.sh
+++ b/scaffold.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# ⚠️ ARCHIVAL — superseded one-shot scaffolder. It generated the solution + service projects
+# at net8.0 with the EF SqlServer provider, both since replaced. The canonical state is the
+# committed .csproj files (net10.0 + Npgsql). Do NOT re-run this; kept for history.
+
 # Project list
 SERVICES=("Auth" "User" "Quiz" "Result" "Notification")
 


### PR DESCRIPTION
**Phase 1** of spec 0002 (production platform). Docs only.

Rewords the living stale platform claims (SQL Server / Codespaces / local-Docker-blocked / gateway-pending / not-pushed) to current, and gives the repo a real entry point:
- **README** — new `Getting started` (Docker Desktop + .NET 10 SDK + Node 20 → `cp .env.example .env` → `docker compose up` → `npm run dev`); corrected `Status` (Layer-0 done, frontend built per spec 0001, platform in progress per 0002).
- **foundation.md** — §8 v1-scope marks fixed + a Layer-0-complete banner; §10 migration cost paid; §11 bus-factor note updated (repo public + pushed + protected).
- **library-docs.md / build-graph.md** — the net8/`UseSqlServer`/regenerate-migrations/Codespace gotchas dropped; `mssql`→`postgres` swap marked done; gateway + Railway pointed at spec 0002.
- Archival banners on `scaffold.sh`, `add_docker.sh`, `docs/project-environment-and-architecture.md`.

Satisfies **AC-13**. The README Getting started describes the target `docker compose` + gateway flow, finalised in phases 2–3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)