### PR TITLE
feat(infra): one-command local dev on docker compose (spec 0002 phase 2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Keep the Docker build context small. Every service Dockerfile does `COPY . .`
+# from the repo root, so without this it would drag in build output, the SPA's
+# node_modules, git history, and local secrets.
+#
+# NOTE: frontend/ and design-system/ are intentionally NOT excluded — the gateway
+# image builds the SPA (npm run build), which imports the design tokens from
+# design-system/.
+**/bin
+**/obj
+**/node_modules
+frontend/dist
+.git
+.github
+.vs
+**/.vs
+**/*.user
+.env
+quiz-trash
+docs
+context

--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,13 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [feat] Production platform Phase 2 — local dev on Docker (compose fixed, .dockerignore)
+- **Date:** 2026-07-13
+- **Area:** infra
+- **What:** `docker compose up` is now the one-command local stack. Added `/.dockerignore` (excludes `bin`/`obj`/`node_modules`/`.git`/`.env`/`docs`/`context` so the `COPY . .` build context stays small; deliberately keeps `frontend/` + `design-system/` for the gateway's SPA build in Phase 4). Rewrote `docker-compose.yml`: dropped the obsolete `version:` key; a non-colliding host-port block (auth `15001`, user `15002`, quiz `15224`, result `15004`) that never clashes with the `dotnet run` launchSettings ports; every app service now gates on `depends_on: postgres: {condition: service_healthy}`; unified the DB password + JWT secret wiring (result/notification previously hardcoded the password); consistent `ASPNETCORE_ENVIRONMENT=Development`; **NotificationService dropped** (deferred stub; its DB is still created by `postgres-init.sql`).
+- **Result:** verified end-to-end — `docker compose up -d --build` builds all 4 service images, Postgres comes up healthy, the services start only after (health-gated), no port collision; `GET :15002/api/profile` → 401 and `POST :15001/api/auth/login {}` → 400 prove they serve and reach their pipeline. Satisfies **AC-1** (the SPA-proxies-to-gateway half lands with the gateway in Phase 3).
+- **Notes:** **Root-caused a real build blocker.** Stray `bin\Debug` directories (a literal backslash in the name) in the three built API projects — MSBuild BuildHost artifacts from a Windows-style output path written on macOS (a C# IDE / Roslyn tool). The backslash breaks MSBuild's Unix wildcard globbing (`**/*.resx`, `**/*.cs` …), so every clean `dotnet build -o` and Docker image build failed with **MSB3552**, while warm-`obj` local builds and fresh-checkout CI stayed green. Deleted them (untracked; a fresh checkout never has them). If a local build suddenly fails with a `**/*.resx` glob error, delete any recreated `bin\Debug` dirs. The in-container `UseHttpsRedirection()` logs a harmless "Failed to determine https port" warning (TLS terminates at the gateway edge; Phase 3/6 addresses it).
+
 ### [docs] Production platform Phase 1 — reconcile stale env/arch docs + add a run-doc
 - **Date:** 2026-07-13
 - **Area:** context / docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,10 @@
-version: '3.4'
+# Local dev stack (spec 0002). `docker compose up` brings up Postgres + the built
+# services. The gateway service is added in Phase 3; the SPA runs on the host Vite
+# server (hot reload) proxying to the gateway. NotificationService is deferred (stub)
+# and omitted; its database is still created by docker/postgres-init.sql for later.
+#
+# Host ports use a non-colliding 150xx block so they never clash with the `dotnet run`
+# launchSettings ports (Auth 5005, User 5079, Quiz 5224). Containers all listen on 8080.
 
 services:
   postgres:
@@ -25,12 +31,14 @@ services:
       context: .
       dockerfile: src/Services/AuthService/AuthService.API/Dockerfile
     ports:
-      - "5001:8080"
+      - "15001:8080"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
+      - ASPNETCORE_ENVIRONMENT=Development
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=authdb;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}
-      - JwtSettings__Secret=${JWT_SECRET}
+      - JwtSettings__Secret=${JWT_SECRET:-local-dev-only-insecure-secret-change-me}
 
   userservice:
     image: ${DOCKER_REGISTRY-}userservice
@@ -38,12 +46,14 @@ services:
       context: .
       dockerfile: src/Services/UserService/UserService.API/Dockerfile
     ports:
-      - "5002:8080"
+      - "15002:8080"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
+      - ASPNETCORE_ENVIRONMENT=Development
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=userdb;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}
-      - JwtSettings__Secret=${JWT_SECRET}
+      - JwtSettings__Secret=${JWT_SECRET:-local-dev-only-insecure-secret-change-me}
 
   quizservice:
     image: ${DOCKER_REGISTRY-}quizservice
@@ -51,13 +61,14 @@ services:
       context: .
       dockerfile: src/Services/QuizService/QuizService.API/Dockerfile
     ports:
-      - "5224:8080"
+      - "15224:8080"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=quizdb;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}
-      - JwtSettings__Secret=${JWT_SECRET}
       - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=quizdb;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}
+      - JwtSettings__Secret=${JWT_SECRET:-local-dev-only-insecure-secret-change-me}
 
   resultservice:
     image: ${DOCKER_REGISTRY-}resultservice
@@ -65,23 +76,14 @@ services:
       context: .
       dockerfile: src/Services/ResultService/ResultService.API/Dockerfile
     ports:
-      - "5004:8080"
+      - "15004:8080"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=resultdb;Username=postgres;Password=postgres
-
-  notificationservice:
-    image: ${DOCKER_REGISTRY-}notificationservice
-    build:
-      context: .
-      dockerfile: src/Services/NotificationService/NotificationService.API/Dockerfile
-    ports:
-      - "5005:8080"
-    depends_on:
-      - postgres
-    environment:
-      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=notificationdb;Username=postgres;Password=postgres
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=resultdb;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}
+      - JwtSettings__Secret=${JWT_SECRET:-local-dev-only-insecure-secret-change-me}
 
 volumes:
   pgdata:


### PR DESCRIPTION
**Phase 2** of spec 0002. Makes `docker compose up` the canonical local stack.

- **`.dockerignore`** (new) — keeps the `COPY . .` build context small; deliberately keeps `frontend/` + `design-system/` for the gateway SPA build (phase 4).
- **`docker-compose.yml`** — drop the obsolete `version:` key; non-colliding `150xx` host ports (no clash with `dotnet run` launchSettings); gate every app service on the Postgres healthcheck; unify DB password + JWT secret wiring; consistent `Development` env; drop the deferred NotificationService.

**Verified end-to-end:** `docker compose up -d --build` builds all 4 service images, Postgres comes up healthy, services start only after (health-gated), no port collision; `GET :15002/api/profile` → 401 and `POST :15001/api/auth/login {}` → 400 prove they serve. Satisfies **AC-1**.

Root-caused + cleared a real blocker: stray `bin\\Debug` (backslash) dirs from a C# IDE BuildHost broke MSBuild's Unix globbing (MSB3552) on clean/Docker builds — untracked, deleted, absent from fresh checkouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)