### PR TITLE
ci: cover the whole product — frontend, Postgres, drift, CodeQL, commitlint (spec 0002 phase 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,31 @@ on:
     branches: [main]
 
 jobs:
+  # NOTE: keep this job named `build-and-test` — branch protection requires that
+  # exact check. New job names (frontend, commitlint, codeql) are added to the
+  # required set in a follow-up, after they have reported once.
   build-and-test:
+    name: build-and-test
     runs-on: ubuntu-latest
+    services:
+      # Available for integration tests. The current suite is unit tests (xUnit/Moq)
+      # and does not use it yet; integration tests against real Postgres are a follow-up.
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 3s
+          --health-timeout 3s
+          --health-retries 15
+    env:
+      # Design-time config for the EF drift check's host build (no real connection is made).
+      ConnectionStrings__DefaultConnection: "Host=localhost;Port=5432;Database=postgres;Username=postgres;Password=postgres"
+      JwtSettings__Secret: "ci-design-time-only-not-a-real-secret-0123456789abcdef"
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET 10
@@ -19,5 +42,71 @@ jobs:
         run: dotnet restore QuizApp.sln
       - name: Build
         run: dotnet build QuizApp.sln --no-restore -c Release
+      - name: Test (with coverage)
+        run: dotnet test QuizApp.sln --no-build -c Release --collect:"XPlat Code Coverage" --results-directory ./coverage
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: ./coverage/**/coverage.cobertura.xml
+          if-no-files-found: warn
+      - name: Restore EF tool
+        run: dotnet tool restore
+      # AC-6: fails if any EF model has changes not captured in a migration. Runs LAST
+      # and with --no-build — EF's design-time host can write a stray bin\Debug dir that
+      # poisons MSBuild globbing, so we keep it after the real build and skip a rebuild.
+      - name: Migration drift check
+        run: |
+          set -e
+          ef() { dotnet tool run dotnet-ef migrations has-pending-model-changes --no-build --configuration Release "$@"; }
+          ef --project src/Services/AuthService/AuthService.Infrastructure --startup-project src/Services/AuthService/AuthService.API --context AuthDbContext
+          ef --project src/Services/UserService/UserService.Infrastructure --startup-project src/Services/UserService/UserService.API --context UserDbContext
+          ef --project src/Services/QuizService/QuizService.Infrastructure --startup-project src/Services/QuizService/QuizService.API --context QuizDbContext
+
+  frontend:
+    name: frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Lint
+        run: npm run lint
       - name: Test
-        run: dotnet test QuizApp.sln --no-build -c Release
+        run: npm run test
+      - name: Build (tsc + vite)
+        run: npm run build
+
+  commitlint:
+    name: commitlint
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Conventional Commits (mirrors .githooks/commit-msg)
+        run: |
+          pattern='^(feat|fix|refactor|chore|docs|test|build|perf|ci|style|revert)(\([a-z0-9./_-]+\))?!?: .+'
+          fail=0
+          for sha in $(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}); do
+            subject=$(git log -1 --format=%s "$sha")
+            case "$subject" in
+              "Merge "*|"Revert "*|"fixup! "*|"squash! "*) continue ;;
+            esac
+            if ! printf '%s' "$subject" | grep -Eq "$pattern"; then
+              echo "::error::Non-conventional commit message: $subject"
+              fail=1
+            fi
+          done
+          exit $fail

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '31 4 * * 1'
+
+jobs:
+  analyze:
+    name: codeql
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [csharp, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET 10
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          language: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,13 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [ci] Production platform Phase 5 — expand CI (frontend, Postgres, drift, coverage, CodeQL, commitlint)
+- **Date:** 2026-07-13
+- **Area:** infra / ci
+- **What:** Widened CI from a single .NET build+test to cover the whole product. `ci.yml`: **build-and-test** (kept the name so branch protection isn't broken) now runs with a **Postgres 17 service**, collects **coverage** (`--collect:"XPlat Code Coverage"`, uploaded as an artifact), restores the EF tool, and runs a **migration-drift check** (`dotnet ef migrations has-pending-model-changes --no-build` for Auth/User/Quiz — **AC-6**) as the last step, so the EF design-time host's stray `bin\Debug` can't poison the build. New **frontend** job (Node 20: `npm ci` → lint → vitest → build). New **commitlint** job (Conventional Commits over the PR commit range, mirroring `.githooks/commit-msg`). New `codeql.yml`: **CodeQL** for `csharp` + `javascript-typescript` (also weekly on cron). Satisfies **AC-5**, **AC-6**.
+- **Result:** both workflows parse; the drift check verified locally clean for all 3 contexts (`AuthDbContext`/`UserDbContext`/`QuizDbContext` in sync). The full check set (build-and-test + frontend + codeql + commitlint) is verified by this PR's own CI run.
+- **Notes:** The Postgres service is ready for integration tests; the current suite is unit tests (integration tests are a follow-up). Root-caused the `--no-build` need: `dotnet ef`'s Roslyn BuildHost writes a stray `bin\Debug` (backslash) on non-Windows that breaks MSBuild globbing; `--no-build` + running the check last sidesteps it. Job names are now final, so **Phase 7** can add `frontend`/`codeql`/`commitlint` to the required status checks (only after they have each reported once).
+
 ### [feat] Production platform Phase 4 — service /health endpoints (AC-4 complete)
 - **Date:** 2026-07-13
 - **Area:** backend


### PR DESCRIPTION
**Phase 5** of spec 0002. Widens CI from a single .NET build+test to the whole product.

- **build-and-test** (name kept — branch protection requires it): + Postgres 17 service, + coverage (artifact), + EF **migration-drift check** (`has-pending-model-changes --no-build`, last step — **AC-6**).
- **frontend** (new): Node 20 → `npm ci` → lint → vitest → build.
- **commitlint** (new): Conventional Commits over the PR commits (mirrors the client-side hook).
- **codeql.yml** (new): CodeQL for csharp + javascript-typescript.

Satisfies **AC-5**, **AC-6**. Job names are final so Phase 7 can require them (after they report once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)