### PR TITLE
ci: GitHub governance files (spec 0002 phase 7)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners. Solo project, so one owner for everything. The explicit lines for
+# the source-of-truth docs are documentational (they mark the load-bearing areas).
+* @Chineme123
+
+/context/ @Chineme123
+/docs/specs/ @Chineme123
+/.github/ @Chineme123

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Backend NuGet packages (the solution at the repo root).
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+
+  # Frontend npm packages.
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+
+  # The GitHub Actions the workflows pin.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this change do, and why? Keep it tight. -->
+
+## Linked spec / use case
+
+<!-- e.g. spec 0002 phase N · docs/specs/000X · UCn · or "n/a" -->
+
+## How it was verified
+
+<!-- Build/tests/CI, a local run, curl output, a screenshot — how you know it works. -->
+
+## Definition of done (from CLAUDE.md)
+
+- [ ] `context/progress-log.md` entry added (mandatory for real work)
+- [ ] If a decision changed a context file, that file is updated too (the drift rule)
+- [ ] Build + tests green (`dotnet build QuizApp.sln`, `dotnet test`, and `frontend/` checks if touched)
+- [ ] No secrets committed (DB password, JWT key, API keys stay in env / user-secrets)

--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,12 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [ci] Production platform Phase 7 — GitHub governance as code
+- **Date:** 2026-07-13
+- **Area:** infra / ci
+- **What:** Added the repo-hygiene files — `.github/dependabot.yml` (weekly updates: nuget at `/`, npm at `/frontend`, github-actions), `.github/CODEOWNERS` (`* @Chineme123` + the source-of-truth areas), `.github/pull_request_template.md` (summary, linked spec, verification, the CLAUDE.md definition-of-done checklist) — and refined branch protection on `main` via `gh api`: required status checks are now `build-and-test`, `frontend`, `commitlint`, `codeql (csharp)`, `codeql (javascript-typescript)`; a PR is required (0 approvals — a solo dev can't self-approve, so 1 would deadlock merges); `enforce_admins` on; force-pushes/deletions off; strict (up-to-date-before-merge) kept. Satisfies **AC-11**, **AC-12**.
+- **Notes:** Done ahead of Phase 6 (CD) since it needs no Railway. The required-check names were pinned only after the Phase 5 jobs each reported once (PR #35), so no merge deadlocks on a check that never posts. CodeQL now adds ~3–4 min to every PR merge — the cost of the required security gate.
+
 ### [ci] Production platform Phase 5 — expand CI (frontend, Postgres, drift, coverage, CodeQL, commitlint)
 - **Date:** 2026-07-13
 - **Area:** infra / ci


### PR DESCRIPTION
**Phase 7** (governance files). Dependabot (nuget/npm/actions), CODEOWNERS, PR template. The branch-protection refinement (require frontend/codeql/commitlint + PR + enforce_admins) is applied via `gh api` right after this merges — the check names are now stable (Phase 5, PR #35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)