### PR TITLE
feat(services): migrate-on-startup for Auth/User/Quiz (spec 0002 phase 6 pt.1)

### DIFF
--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,13 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [feat] Production platform Phase 6 (part 1) — migrate-on-startup + Railway project provisioned
+- **Date:** 2026-07-13
+- **Area:** backend / infra
+- **What:** Added an env-gated **migrate-on-startup** hook to AuthService, UserService, and QuizService (`if RUN_MIGRATIONS_ON_STARTUP: db.Database.Migrate()` right after `builder.Build()`), and set `RUN_MIGRATIONS_ON_STARTUP=true` on those three services in `docker-compose.yml`. This is what makes the services create their tables on Railway (the databases are otherwise empty — the init script only creates the DBs), and it also fixes local dev (the compose DBs were empty too). The QuizService Development seeder still handles demo data separately. **Provisioned the Railway side** (CLI, on the developer's authenticated session): project `quiztin`, a managed **PostgreSQL**, and the four databases `authdb`/`userdb`/`quizdb`/`resultdb`. Satisfies **AC-8** (and the DB half of **AC-9**).
+- **Result:** verified end-to-end locally — `docker compose up --build`, then `POST /api/auth/register` **through the gateway** returns **200** with `{token, userId, role}` and the refresh cookie, and `authdb` now has its tables. First full proof of gateway → service → self-migrated DB → auth.
+- **Notes:** ResultService is a stub with no DbContext, so it gets no hook. Remaining Phase 6: create the 4 Railway services (gateway + Auth/User/Quiz) with their Dockerfile paths + prod env vars, deploy, wire the gateway's public domain, and add `RAILWAY_TOKEN` + `deploy.yml` for CI-gated CD.
+
 ### [ci] Production platform Phase 7 — GitHub governance as code
 - **Date:** 2026-07-13
 - **Area:** infra / ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
         condition: service_healthy
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+      - RUN_MIGRATIONS_ON_STARTUP=true
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=authdb;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}
       - JwtSettings__Secret=${JWT_SECRET:-local-dev-only-insecure-secret-change-me}
 
@@ -52,6 +53,7 @@ services:
         condition: service_healthy
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+      - RUN_MIGRATIONS_ON_STARTUP=true
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=userdb;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}
       - JwtSettings__Secret=${JWT_SECRET:-local-dev-only-insecure-secret-change-me}
 
@@ -67,6 +69,7 @@ services:
         condition: service_healthy
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+      - RUN_MIGRATIONS_ON_STARTUP=true
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=quizdb;Username=postgres;Password=${POSTGRES_PASSWORD:-postgres}
       - JwtSettings__Secret=${JWT_SECRET:-local-dev-only-insecure-secret-change-me}
 

--- a/src/Services/AuthService/AuthService.API/Program.cs
+++ b/src/Services/AuthService/AuthService.API/Program.cs
@@ -37,6 +37,14 @@ builder.Services.AddScoped<IAuthService, AuthAppService>();
 
 var app = builder.Build();
 
+// Apply EF migrations at startup when enabled (spec 0002). On in production (Railway)
+// and in docker-compose so the databases have their tables; off by default otherwise.
+if (app.Configuration.GetValue<bool>("RUN_MIGRATIONS_ON_STARTUP"))
+{
+    using var migrationScope = app.Services.CreateScope();
+    migrationScope.ServiceProvider.GetRequiredService<AuthDbContext>().Database.Migrate();
+}
+
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();

--- a/src/Services/QuizService/QuizService.API/Program.cs
+++ b/src/Services/QuizService/QuizService.API/Program.cs
@@ -92,6 +92,15 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 var app = builder.Build();
 
+// Apply EF migrations at startup when enabled (spec 0002). On in production (Railway)
+// and in docker-compose so the databases have their tables; off by default otherwise.
+// The Development seeder below still handles demo data.
+if (app.Configuration.GetValue<bool>("RUN_MIGRATIONS_ON_STARTUP"))
+{
+    using var migrationScope = app.Services.CreateScope();
+    migrationScope.ServiceProvider.GetRequiredService<QuizDbContext>().Database.Migrate();
+}
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {

--- a/src/Services/UserService/UserService.API/Program.cs
+++ b/src/Services/UserService/UserService.API/Program.cs
@@ -85,6 +85,14 @@ builder.Services.AddAuthentication(options =>
 
 var app = builder.Build();
 
+// Apply EF migrations at startup when enabled (spec 0002). On in production (Railway)
+// and in docker-compose so the databases have their tables; off by default otherwise.
+if (app.Configuration.GetValue<bool>("RUN_MIGRATIONS_ON_STARTUP"))
+{
+    using var migrationScope = app.Services.CreateScope();
+    migrationScope.ServiceProvider.GetRequiredService<UserDbContext>().Database.Migrate();
+}
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
**Phase 6 (part 1)** of spec 0002. Env-gated migrate-on-startup hook (`RUN_MIGRATIONS_ON_STARTUP`) in Auth/User/Quiz + enabled in compose. Makes the services create their tables on Railway and locally (both had empty DBs). Verified: register **through the gateway** → 200 + session; `authdb` tables created. Satisfies **AC-8**.

Railway side already provisioned via CLI: project `quiztin`, managed Postgres, and the 4 databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)