### PR TITLE
chore(deps): migrate Swashbuckle to 10 (Microsoft.OpenApi v2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,13 +17,6 @@ updates:
       nuget-safe:
         patterns: ["*"]
         update-types: ["minor", "patch"]
-    ignore:
-      # Swashbuckle 7+ moves onto Microsoft.OpenApi v2, which drops the
-      # Microsoft.OpenApi.Models namespace the API services use for the JWT
-      # Swagger setup (build break, CS0234 — see closed #60). Defer the major
-      # migration to its own task; keep taking Swashbuckle minor/patch.
-      - dependency-name: "Swashbuckle.AspNetCore"
-        update-types: ["version-update:semver-major"]
 
   # Frontend npm packages.
   - package-ecosystem: npm

--- a/context/library-docs.md
+++ b/context/library-docs.md
@@ -41,8 +41,9 @@
 - **Gotchas:** the model id is a **config value**, not hardcoded (default to a current cost-effective Claude model for feedback; a stronger one for generation if quality demands). API key from secrets, only in the calling service. Validate model output before persisting (`security.md` §1). Always wire the fallback path first so the feature works before the model is connected.
 
 ### Swashbuckle.AspNetCore — ✅ (dev)
+- **Version:** **10.x** across all five services (bumped from 6.9.0). v10 pulls in **Microsoft.OpenApi v2** transitively.
 - **How used:** Swagger UI per service for manual testing in Development.
-- **Gotchas:** standardize the Bearer security scheme across services (QuizService registers it as `ApiKey`-type Bearer; keep one consistent definition).
+- **Gotchas:** Microsoft.OpenApi v2 changed the API surface — `using Microsoft.OpenApi;` (the old `Microsoft.OpenApi.Models` namespace was removed); `OpenApiSecurityScheme` lost its `.Reference` property, so the requirement references a scheme via `new OpenApiSecuritySchemeReference("Bearer", document)`; and Swashbuckle's `AddSecurityRequirement` now takes a **`Func<OpenApiDocument, OpenApiSecurityRequirement>`** delegate, not the object. `OpenApiSecurityRequirement`'s value type is `List<string>` (an array won't compile). The Bearer scheme still differs per service (QuizService `ApiKey`-type, UserService `Http`-type) — both render the Authorize button; standardize only if it matters.
 
 ### xUnit + Moq — ✅ (test)
 - **How used:** unit tests for the domain (state machine, scoring, gating). `QuizAttemptTests` exists.
@@ -100,7 +101,7 @@ Do not install anything outside this list without adding it here first (with a w
 | Microsoft.AspNetCore.Authentication.JwtBearer (10.x) | JWT validation | ✅ |
 | System.IdentityModel.Tokens.Jwt (8.x) | JWT issuing (AuthService) | ✅ |
 | Yarp.ReverseProxy (2.x) | API gateway | ✅ (new) |
-| Swashbuckle.AspNetCore (6–7.x) | Swagger UI (dev) | ✅ |
+| Swashbuckle.AspNetCore (10.x) | Swagger UI (dev) | ✅ |
 | Anthropic Claude client (typed HttpClient wrapper, or `Anthropic.SDK`) | AI generation + feedback | 🕗 mechanism |
 | xUnit, Moq, coverlet | Testing | ✅ |
 | React 19, Vite 8, TypeScript | Frontend SPA | ✅ (spec 0001) |

--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,16 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [chore] Swashbuckle 6→10 / Microsoft.OpenApi v2 migration — all five API services
+- **Date:** 2026-07-14
+- **Area:** backend
+- **What:** Completed the deferred Swashbuckle major (the follow-up flagged during the dependency-PR cleanup below).
+  - Bumped `Swashbuckle.AspNetCore` **6.9.0 → 10.2.3** in all five `*.API.csproj` (Quiz, User, Auth, Result, Notification) — not just the two the build error named, to avoid mixed major versions across the services.
+  - Migrated the JWT Swagger wiring in `QuizService.API` and `UserService.API` `Program.cs` to **Microsoft.OpenApi v2** (Auth/Result/Notification only call `AddSwaggerGen()`, so no code change): `using Microsoft.OpenApi.Models` → `using Microsoft.OpenApi`; the old `OpenApiSecurityScheme { Reference = new OpenApiReference {…} }` → `new OpenApiSecuritySchemeReference("Bearer", document)`; and `AddSecurityRequirement(…)` now takes a `Func<OpenApiDocument, OpenApiSecurityRequirement>` delegate (its value type is `List<string>`, not an array).
+  - Removed the Swashbuckle-major `ignore` from `.github/dependabot.yml` (its rationale — deferring this migration — no longer applies), and updated `library-docs.md` (the entry + approved-list row) with the v2 API notes.
+- **Result:** `dotnet build QuizApp.sln` → **0 errors**; `dotnet test` → **42/42 pass** (Quiz 6, User 9, Auth 27). Ran both migrated services and confirmed the generated OpenAPI doc still carries the `Bearer` scheme + the security requirement (`[{"Bearer": []}]`) and Swagger UI returns 200 — the Authorize button renders. QuizService was booted with migrate+seed against a throwaway Postgres.
+- **Notes:** The local .NET 10 SDK had vanished from `~/.dotnet`; reinstalled **10.0.302** (satisfies `global.json` 10.0.301 + latestMinor). Migration articles are unreliable here (version-confused between Swashbuckle 9 and 10); the authoritative sources were the Microsoft.OpenApi 2.0 type definitions and the compiler itself.
+
 ### [chore] Dependency-PR cleanup — cleared the open Dependabot backlog
 - **Date:** 2026-07-14
 - **Area:** infra / context

--- a/src/Services/AuthService/AuthService.API/AuthService.API.csproj
+++ b/src/Services/AuthService/AuthService.API/AuthService.API.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/NotificationService/NotificationService.API/NotificationService.API.csproj
+++ b/src/Services/NotificationService/NotificationService.API/NotificationService.API.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/QuizService/QuizService.API/Program.cs
+++ b/src/Services/QuizService/QuizService.API/Program.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using QuizService.Application.Interfaces;
 using QuizService.Application.Services;
 using QuizService.Application.Facades;
@@ -31,18 +31,11 @@ builder.Services.AddSwaggerGen(c =>
         Type = SecuritySchemeType.ApiKey,
         Scheme = "Bearer"
     });
-    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
     {
         {
-            new OpenApiSecurityScheme
-            {
-                Reference = new OpenApiReference
-                {
-                    Type = ReferenceType.SecurityScheme,
-                    Id = "Bearer"
-                }
-            },
-            new string[] {}
+            new OpenApiSecuritySchemeReference("Bearer", document),
+            new List<string>()
         }
     });
 });

--- a/src/Services/QuizService/QuizService.API/QuizService.API.csproj
+++ b/src/Services/QuizService/QuizService.API/QuizService.API.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/ResultService/ResultService.API/ResultService.API.csproj
+++ b/src/Services/ResultService/ResultService.API/ResultService.API.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/UserService/UserService.API/Program.cs
+++ b/src/Services/UserService/UserService.API/Program.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using System.Text;
 using UserService.Application.Interfaces;
 using UserService.Application.Strategies;
@@ -27,18 +27,11 @@ builder.Services.AddSwaggerGen(c =>
         Type = SecuritySchemeType.Http,
         Scheme = "bearer"
     });
-    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
     {
         {
-            new OpenApiSecurityScheme
-            {
-                Reference = new OpenApiReference
-                {
-                    Type = ReferenceType.SecurityScheme,
-                    Id = "Bearer"
-                }
-            },
-            new string[] { }
+            new OpenApiSecuritySchemeReference("Bearer", document),
+            new List<string>()
         }
     });
 });

--- a/src/Services/UserService/UserService.API/UserService.API.csproj
+++ b/src/Services/UserService/UserService.API/UserService.API.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Completes the deferred Swashbuckle major (follow-up from the Dependabot PR cleanup; #60 was closed and the major was ignored pending this).

## What
- Bump `Swashbuckle.AspNetCore` **6.9.0 → 10.2.3** in all five `*.API.csproj` (Quiz, User, Auth, Result, Notification).
- Migrate the JWT Swagger wiring in **QuizService.API** and **UserService.API** `Program.cs` to **Microsoft.OpenApi v2**:
  - `using Microsoft.OpenApi` (the `Microsoft.OpenApi.Models` namespace was removed → `CS0234`)
  - `OpenApiSecurityScheme` lost `.Reference`; the requirement now uses `new OpenApiSecuritySchemeReference("Bearer", document)`
  - `AddSecurityRequirement` now takes a `Func<OpenApiDocument, OpenApiSecurityRequirement>` delegate (value type is `List<string>`, not an array)
- Auth/Result/Notification only call `AddSwaggerGen()`, so they take the bump with no code change.
- Remove the now-obsolete Swashbuckle-major `ignore` from `dependabot.yml` so future majors surface again.
- Update `library-docs.md` + `progress-log.md` (golden drift rule).

## Verified locally
- `dotnet build QuizApp.sln` → **0 errors**
- `dotnet test` → **42/42 pass**
- Ran **both** migrated services: generated OpenAPI doc keeps the `Bearer` scheme + requirement `[{"Bearer": []}]`, Swagger UI returns 200 (Authorize button renders). QuizService booted with migrate+seed against a throwaway Postgres.