### PR TITLE
docs(context): log the inert CD discovery and the first real deploy

### DIFF
--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,15 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [fix] CD had never deployed — every `Deploy` run was a false green, and production was stale
+- **Date:** 2026-07-16
+- **Area:** infra / docs
+- **What:** Found that the Railway CD pipeline had **never shipped anything**, deployed for real, then made the pipeline actually work.
+  - **The bug:** `.github/workflows/deploy.yml` prints `"RAILWAY_TOKEN not set — skipping deploy."` and then **`exit 0`** — so a skip reports **success**. The secret was never set (`gh secret list` came back empty), so every `Deploy` run since the workflow was written was an ~8 second no-op wearing a green check. `main` was green, `Deploy` was green, and **nothing had reached production** — not spec 0005, not the three follow-up fixes. What was actually live on Railway was stale code from an earlier hand-run `railway up`.
+  - **Deployed for real** from the authenticated local CLI, in the workflow's own order (authservice → userservice → quizservice → **gateway last**, because the gateway resolves the services' private DNS at startup). All four rebuilt from `main @ a786d03`; the gateway image re-ran `npm ci` + `npm run build` and baked the SPA and prerendered landing page into `wwwroot`.
+  - **Fixed the pipeline:** a Railway **project token** was created and set as the repo secret `RAILWAY_TOKEN` (a credential, so the engineer set it — never the agent). A `workflow_dispatch` run then deployed for real.
+- **Notes:** **Verified, never assumed** — a green tick is precisely what lied here, so every claim was checked against evidence. The real run: conclusion `success`, **1m30s** (vs the 8s skip), log shows 4× `Indexing`/`Uploading`/`Build Logs`/`Deploy complete` and **zero** executed skip lines (the one grep hit is GitHub echoing the script source, i.e. the `echo "…"` line, not output). Production after: `/health` → **200** `{"status":"healthy"}`; `/` → **200** at 27,316B, matching the 27,315B prerender from that build; `GET /api/attempts/{id}/result` → **401** — the decisive check, since that route did not exist before 0005 and would have 404'd on the old image. Every merge to `main` now deploys for real. **Still open:** `quizservice` has no `Anthropic`/`Feedback` variables, so feedback runs **deterministic**, not real Claude — set `Anthropic__ApiKey` + `Feedback__AiEnabled=true` to light up the wedge. **Lesson worth keeping:** a CI step that `exit 0`s on missing config reports success for doing nothing. Prefer failing loudly when a deploy can't run, or add a check that the deployed commit matches `main` — a pipeline that silently no-ops is worse than one that's honestly red. Foundation §7 #31 needed no change: the CD *decision* was right all along, it just was not in force.
+
 ### [fix] Scope quiz submit to the authenticated caller (spec 0005 token-scoping gap)
 - **Date:** 2026-07-15
 - **Area:** backend (QuizService)


### PR DESCRIPTION
Records today's infrastructure finding in the progress log — the ritual `CLAUDE.md` calls *"the one ritual that never lapses"*.

## Why this matters

`.github/workflows/deploy.yml` runs `exit 0` when `RAILWAY_TOKEN` is unset, so a **skip reported success**. The secret was never set, meaning **every `Deploy` run since the workflow was written was an ~8 second no-op wearing a green check** — `main` was green, `Deploy` was green, and nothing had ever reached production. Prod was serving stale pre-0005 code from an earlier hand-run `railway up`.

That's worth logging so it's never rediscovered the hard way: a pipeline that silently no-ops is worse than one that's honestly red.

## What the entry records

- The bug and how it hid (false green, ~8s runtime, empty `gh secret list`)
- The manual deploy of all four services from `main @ a786d03` (gateway last — it resolves the services' private DNS at startup)
- The fix: a Railway project token set as `RAILWAY_TOKEN` (a credential — set by the engineer, never the agent)
- **Verification by evidence, not by the green tick**: 1m30s vs 8s, zero *executed* skip lines, and a live **401** on the 0005 result route that would have **404**'d on the old image
- Still open: no `Anthropic`/`Feedback` vars on `quizservice`, so feedback is deterministic, not real Claude

Docs only — no code changes. Foundation §7 #31 needed no edit: the CD *decision* was correct all along, it simply was not in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)