### PR TITLE
chore(deploy): railway.json for the modular-monolith single service

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "src/Quiztin.Api/Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 120,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
Pins the Railway build to the host Dockerfile (`src/Quiztin.Api/Dockerfile`) with a `/health` check, so the single `quiztin` service builds correctly after the monolith migration (spec 0007). The Railway project reconfiguration (create the `quiztin` service, env vars, retire the four old services) is done on the platform, tracked separately.