### PR TITLE
test(take): de-flake navigator assertion by awaiting the "answered" label

### DIFF
--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,12 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [fix] De-flake the take-quiz navigator test
+- **Date:** 2026-07-18
+- **Area:** apps/frontend
+- **What:** `TakeQuizPage.test.tsx` → "shows one question at a time with the countdown and the navigator" intermittently failed in CI (`Unable to find an accessible element with role "button" and name "Question 1, answered"`). The assertion used a synchronous `getByRole` for the navigator's "answered" label, which settles a render *after* the quiz title (`findByText('Networking basics')`) — once the saved draft answers hydrate the form state. Changed that one query to `await screen.findByRole(...)` so it waits for the label; Q2's "not answered yet" stays synchronous (the navigator is fully rendered by then). Other tests in the file already awaited correctly.
+- **Notes:** Verified with 8× single-file runs + a full `npm run test` (19 files / 87 tests) all green. Spec 0006 (take-quiz screen) test code; no product code touched.
+
 ### [refactor] Microservices → modular monolith (spec 0007); profile FK bug fixed
 - **Date:** 2026-07-18
 - **Area:** backend / infra / context

--- a/frontend/src/features/take/TakeQuizPage.test.tsx
+++ b/frontend/src/features/take/TakeQuizPage.test.tsx
@@ -69,8 +69,11 @@ describe('TakeQuizPage', () => {
     expect(screen.getByText('Which layer routes packets between networks?')).toBeInTheDocument();
     expect(screen.queryByText('Name the protocol that resolves names to addresses.')).not.toBeInTheDocument();
     expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
-    // The navigator says the state in words, not by colour alone.
-    expect(screen.getByRole('button', { name: 'Question 1, answered' })).toBeInTheDocument();
+    // The navigator says the state in words, not by colour alone. Await the "answered"
+    // label: it settles a render after the title, once the saved draft answers hydrate the
+    // form state, so a synchronous query here races that update (flaky in CI). Once Q1 reads
+    // "answered" the navigator is fully rendered, so Q2 can be queried synchronously.
+    expect(await screen.findByRole('button', { name: 'Question 1, answered' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Question 2, not answered yet' })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## What

`TakeQuizPage.test.tsx` → **"shows one question at a time with the countdown and the navigator"** intermittently failed in CI:

```
Unable to find an accessible element with the role "button" and name "Question 1, answered"
```

## Why it was flaky

A render race. The test awaits the quiz title (`findByText('Networking basics')`), then queried the navigator's `Question 1, answered` button **synchronously** with `getByRole`. But that "answered" label settles a render *later* — only once the saved draft answers (`draftAnswers: { q1: '1' }`) hydrate the form state. Most runs won that race; CI sometimes lost it.

## The fix

Await the label so the query retries until it appears:

```ts
expect(await screen.findByRole('button', { name: 'Question 1, answered' })).toBeInTheDocument();
```

Q2's `Question 2, not answered yet` stays a synchronous `getByRole` — once Q1 reads "answered" the navigator is fully rendered, so it's settled. The other six tests in the file already await correctly; none needed changes.

## Verification

- 8× runs of the single file → **7/7 passed** every time.
- Full frontend suite → **19 files / 87 tests**, all green.

Also adds the mandatory `progress-log.md` entry (per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)