### PR TITLE
chore(deps): ignore Swashbuckle.AspNetCore major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,13 @@ updates:
       nuget-safe:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # Swashbuckle 7+ moves onto Microsoft.OpenApi v2, which drops the
+      # Microsoft.OpenApi.Models namespace the API services use for the JWT
+      # Swagger setup (build break, CS0234 — see closed #60). Defer the major
+      # migration to its own task; keep taking Swashbuckle minor/patch.
+      - dependency-name: "Swashbuckle.AspNetCore"
+        update-types: ["version-update:semver-major"]
 
   # Frontend npm packages.
   - package-ecosystem: npm

--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,12 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [chore] Ignore Swashbuckle.AspNetCore major bumps in Dependabot
+- **Date:** 2026-07-20
+- **Area:** infra / ci
+- **What:** Added an `ignore` for `Swashbuckle.AspNetCore` **major** version updates to the nuget group in [.github/dependabot.yml](../.github/dependabot.yml), so Dependabot stops re-opening the major bump that breaks the build. Swashbuckle 7+ moves onto Microsoft.OpenApi v2, which drops the `Microsoft.OpenApi.Models` namespace the Swagger/JWT setup uses (CS0234, closed `#60`). Minor and patch Swashbuckle updates still auto-take.
+- **Notes:** Reconciled in from the dropped `chore/dependabot-ignore-swashbuckle-major` branch — its change was on neither `main`, so this restores it rather than dropping it. The Swashbuckle 6→10 / Microsoft.OpenApi v2 migration is a separate follow-up (the Swagger wiring now lives in `Quiztin.Api`, not the retired per-service `Program.cs` files the original branch referenced).
+
 ### [chore] Reconciled the outstanding branches into main
 - **Date:** 2026-07-20
 - **Area:** infra / backend


### PR DESCRIPTION
Restores the Dependabot `ignore` for `Swashbuckle.AspNetCore` **major** bumps — it lived on the dropped `chore/dependabot-ignore-swashbuckle-major` branch and was on neither `main`, so Dependabot could keep re-opening the build-breaking major bump.

**Why:** Swashbuckle 7+ moves onto Microsoft.OpenApi v2, which drops the `Microsoft.OpenApi.Models` namespace the Swagger/JWT setup uses (CS0234, closed #60). Minor/patch updates still auto-take. The 6→10 / OpenApi v2 migration stays a separate follow-up (Swagger wiring now lives in `Quiztin.Api`).

CI config only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)