### PR TITLE
fix: copy Identity.Contracts in the Dockerfile so CD deploys (spec 0002)

### DIFF
--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,12 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [fix] Dockerfile copies the Contracts project, so CD can deploy again (found by /check verify of 0002)
+- **Date:** 2026-07-28
+- **Area:** infra / deploy
+- **What:** A /check verify sweep of spec 0002 found the Railway Deploy workflow had failed on the last two merges to main (PR #90, spec 0010; PR #91, the 413 fix), leaving production on **pre-0010 code** (confirmed live: the `/api/classrooms/{id}/results` route 404s on production but 401s locally). **Root cause:** spec 0010 added the `Quiztin.Modules.Identity.Contracts` project, referenced by both the Identity and Assessment modules, but `src/Quiztin.Api/Dockerfile` was never updated to copy it, so `dotnet restore` failed on Railway ("Quiztin.Modules.Identity.Contracts.csproj ... not found"). Added the two missing COPY lines (the csproj into the restore layer, the source into the publish layer), mirroring the other modules. Same class of drift as the CPM Dockerfile fix (`0c3d403`). **Verified with a real `docker build` of the .NET stage:** restore and publish now succeed with the Contracts project present.
+- **Notes:** Deploy is not a required status check, so the red deploys never blocked the merges (the blind spot a /check verify exists to catch). Local `dotnet build` and CI stayed green because they run with every project present; only the Dockerfile's COPY list drifted. Once this lands and deploys, production catches up to main (the 0010 results feature and the 413 fix).
+
 ### [fix] Oversized source upload now returns 413, not 400 (spec 0009, AC-7)
 - **Date:** 2026-07-27
 - **Area:** backend

--- a/src/Quiztin.Api/Dockerfile
+++ b/src/Quiztin.Api/Dockerfile
@@ -21,10 +21,12 @@ WORKDIR /src
 COPY ["Directory.Packages.props", "./"]
 COPY ["src/Quiztin.Api/Quiztin.Api.csproj", "src/Quiztin.Api/"]
 COPY ["src/Quiztin.Modules.Identity/Quiztin.Modules.Identity.csproj", "src/Quiztin.Modules.Identity/"]
+COPY ["src/Quiztin.Modules.Identity.Contracts/Quiztin.Modules.Identity.Contracts.csproj", "src/Quiztin.Modules.Identity.Contracts/"]
 COPY ["src/Quiztin.Modules.Assessment/Quiztin.Modules.Assessment.csproj", "src/Quiztin.Modules.Assessment/"]
 RUN dotnet restore "src/Quiztin.Api/Quiztin.Api.csproj"
 COPY src/Quiztin.Api/ ./src/Quiztin.Api/
 COPY src/Quiztin.Modules.Identity/ ./src/Quiztin.Modules.Identity/
+COPY src/Quiztin.Modules.Identity.Contracts/ ./src/Quiztin.Modules.Identity.Contracts/
 COPY src/Quiztin.Modules.Assessment/ ./src/Quiztin.Modules.Assessment/
 RUN dotnet publish "src/Quiztin.Api/Quiztin.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 


### PR DESCRIPTION
## Fix: copy Identity.Contracts in the Dockerfile so CD deploys again (spec 0002 / 0007)

A `/check verify` sweep of spec 0002 found the Railway **Deploy** workflow has failed on the last two merges to `main` (PR #90, spec 0010; PR #91, the 413 fix), so **production is stale — running pre-0010 code** (confirmed: `/api/classrooms/{id}/results` 404s on production but 401s locally).

### Cause
Spec 0010 added the `Quiztin.Modules.Identity.Contracts` project (referenced by both the Identity and Assessment modules), but `src/Quiztin.Api/Dockerfile` still copied only Api/Identity/Assessment. So `dotnet restore` fails on Railway (`Quiztin.Modules.Identity.Contracts.csproj … not found`). Same class of drift as the earlier CPM Dockerfile fix (`0c3d403`), and invisible to local builds and CI, which run with every project present.

### Fix
Two missing COPY lines, mirroring the other modules: the csproj into the restore layer, and the source into the publish layer.

### Verified
A real `docker build` of the `.NET` stage — `dotnet restore` and `dotnet publish` both succeed with the Contracts project present (the exact step Railway was failing). Local build + backend tests remain green.

### Note
`Deploy` is not a required status check, so these red deploys never blocked the merges — the blind spot this sweep exists to catch. Once this lands, the post-merge Deploy should go green and production catches up to `main` (the 0010 results feature and the 413 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
