### PR TITLE
fix(auth): validate wire userId as a .NET Guid, not z.uuid()

### DIFF
--- a/context/progress-log.md
+++ b/context/progress-log.md
@@ -20,6 +20,12 @@ Category one of: `feature` · `fix` · `refactor` · `chore` · `decision` · `d
 
 ## Entries
 
+### [fix] Seed accounts can sign in again — auth and profile wire schemas use `guid`, not `z.uuid()` (found by /check verify of 0011)
+- **Date:** 2026-07-28
+- **Area:** apps/frontend
+- **What:** The /check verify walk of spec 0011 found that **no seeded account** (`student@quiztin.dev`, `teacher@quiztin.dev`, all of them) could sign in through the UI, even though `POST /api/auth/login` returned **200 with a valid token** — the SPA showed "We could not sign you in." **Root cause:** `authSessionSchema` in `lib/auth/session.ts` validated `userId` with `z.uuid()`, which rejects the seeded .NET GUIDs (e.g. `22222222-0000-0000-0000-000000000002`: a zero version nibble, a valid `Guid` but not an RFC 4122 v4 UUID), so `apiFetch` threw at the schema boundary and the login mutation treated the healthy 200 as a failure. Switched `userId` to the local `guid` primitive (`lib/api/schemas.ts`) — the exact fix the api schemas already carry after the same trap took the quiz list down (spec 0006). Found and fixed the **identical second instance** in `features/profile/profile.schemas.ts` (`profileSchema.userId`), which broke Manage Profile for the same accounts the same way.
+- **Notes:** Real registered accounts were never affected (their DB ids are v4, which `z.uuid()` accepts), so this only ever bit the seed accounts — which is why every green test missed it: the page and flow tests mock the api module, so the wire schema never ran. Locked now by two new **unmocked** wire-schema tests (`lib/auth/session.test.ts`, `features/profile/profile.schemas.test.ts`), mirroring the `classrooms.schemas.test.ts` / `take.schemas.test.ts` guards that exist for exactly this. Verified live against `docker compose up`: the seed student now lands on `/dashboard`, and Manage Profile loads as "Sam Carter". Frontend **172 pass**, `tsc --noEmit` clean. These were the last two `z.uuid()` calls on a wire `userId`; the form schemas (`z.email()`, `z.url()`) are untouched. **Built on branch `fix/wire-guid-schema`.**
+
 ### [feature] Student results index built (spec 0011, tasks 1 to 5) — the last read surface of the core loop
 - **Date:** 2026-07-28
 - **Area:** backend / apps/frontend / db / docs / context

--- a/frontend/src/features/profile/profile.schemas.test.ts
+++ b/frontend/src/features/profile/profile.schemas.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { profileSchema } from './profile.schemas';
+
+/**
+ * The profile wire contract, parsed against the ids the server really sends. The ManageProfile page
+ * test mocks the api, so this schema never runs there; a `userId` shape it is too strict for would
+ * only fail in the browser on a real 200 — the same spec 0006 trap that broke sign in, since the
+ * profile userId is the same plain .NET Guid.
+ */
+describe('profileSchema accepts the ids the server actually sends', () => {
+  // The seed student id: a valid .NET Guid, non v4 (zero version nibble), the case `z.uuid()` rejected.
+  const SEEDED_ID = '22222222-0000-0000-0000-000000000002';
+
+  const base = {
+    userId: SEEDED_ID,
+    displayName: 'Sam Carter',
+    createdAt: '2026-07-28T18:46:30.008574Z',
+    updatedAt: '2026-07-28T18:46:30.008574Z',
+  };
+
+  it('parses a profile for a seeded, non v4 user id', () => {
+    const parsed = profileSchema.parse(base);
+    expect(parsed.userId).toBe(SEEDED_ID);
+    expect(parsed.displayName).toBe('Sam Carter');
+  });
+
+  it('rejects a userId that is not a GUID at all', () => {
+    expect(() => profileSchema.parse({ ...base, userId: 'nope' })).toThrow();
+  });
+});

--- a/frontend/src/features/profile/profile.schemas.ts
+++ b/frontend/src/features/profile/profile.schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { guid } from '@/lib/api/schemas';
 import type { Role } from '@/lib/auth/session';
 
 // The dropdown vocabularies come straight from docs/uc14-ui-ux-brief.md. The server
@@ -19,7 +20,9 @@ export const INSTRUCTOR_TYPE_OPTIONS = INSTRUCTOR_TYPES.map((v) => ({ value: v, 
  * boundary so a drifting backend fails loud here instead of somewhere downstream.
  */
 export const profileSchema = z.object({
-  userId: z.uuid(),
+  // A plain .NET Guid over the wire, so the local `guid`, never `z.uuid()`: a seeded userId
+  // (zero version nibble) would otherwise fail the same way sign in did (spec 0006, session.ts).
+  userId: guid,
   displayName: z.string(),
   bio: z.string().nullish(),
   avatarUrl: z.string().nullish(),

--- a/frontend/src/lib/auth/session.test.ts
+++ b/frontend/src/lib/auth/session.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { authSessionSchema } from './session';
+
+/**
+ * The auth wire contract, parsed against the ids the server really sends.
+ *
+ * Login, register, and refresh all validate through this schema at the boundary, but the page and
+ * flow tests mock the api module, so the schema never runs in them. A `userId` shape the schema is
+ * too strict for sails past every green test and only fails in the browser on a real 200 — which is
+ * exactly how every seed account stopped signing in until this was fixed (the spec 0006 trap).
+ */
+describe('authSessionSchema accepts the ids the server actually sends', () => {
+  // The seed student id from the dev database: a valid .NET Guid, but its zero version nibble makes
+  // it a non v4 UUID, the case `z.uuid()` rejected while /api/auth/login returned a healthy 200.
+  const SEEDED_ID = '22222222-0000-0000-0000-000000000002';
+  // A Guid.NewGuid() style id (v4), as real registered accounts carry. Both must parse.
+  const GENERATED_ID = 'b7f3c1a2-9d4e-4f6a-8b2c-1e5d7a9f0c3b';
+
+  it('parses a session for a seeded, non v4 user id', () => {
+    const parsed = authSessionSchema.parse({ token: 'a.b.c', userId: SEEDED_ID, role: 'Student' });
+    expect(parsed.userId).toBe(SEEDED_ID);
+    expect(parsed.role).toBe('Student');
+  });
+
+  it('parses a session for a generated v4 user id', () => {
+    const parsed = authSessionSchema.parse({ token: 'a.b.c', userId: GENERATED_ID, role: 'Teacher' });
+    expect(parsed.userId).toBe(GENERATED_ID);
+  });
+
+  it('rejects a userId that is not a GUID at all', () => {
+    expect(() =>
+      authSessionSchema.parse({ token: 'a.b.c', userId: 'not-a-guid', role: 'Student' }),
+    ).toThrow();
+  });
+
+  it('rejects an empty token, so a blank session cannot pass', () => {
+    expect(() => authSessionSchema.parse({ token: '', userId: SEEDED_ID, role: 'Student' })).toThrow();
+  });
+
+  it('rejects an unknown role', () => {
+    expect(() =>
+      authSessionSchema.parse({ token: 'a.b.c', userId: SEEDED_ID, role: 'Admin' }),
+    ).toThrow();
+  });
+});

--- a/frontend/src/lib/auth/session.ts
+++ b/frontend/src/lib/auth/session.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { guid } from '@/lib/api/schemas';
 
 export const roleSchema = z.enum(['Student', 'Teacher']);
 export type Role = z.infer<typeof roleSchema>;
@@ -7,10 +8,15 @@ export type Role = z.infer<typeof roleSchema>;
  * The shape every auth endpoint returns (register, login, refresh). Responses
  * are camelCase (verified against the live backend). Validating here means a
  * drifting backend fails loud at the boundary instead of somewhere downstream.
+ *
+ * `userId` is the local `guid`, never `z.uuid()`: the server sends a plain .NET Guid,
+ * and the seeded ids (e.g. `22222222-0000-0000-0000-000000000002`) have a zero version
+ * nibble, so `z.uuid()` rejects them and every seed account fails to sign in on a valid
+ * 200 — the same spec 0006 trap the api schemas already switched away from.
  */
 export const authSessionSchema = z.object({
   token: z.string().min(1),
-  userId: z.uuid(),
+  userId: guid,
   role: roleSchema,
 });
 


### PR DESCRIPTION
## What

Seeded accounts (`student@quiztin.dev`, `teacher@quiztin.dev`, all of them) could not sign in through the UI, even though `POST /api/auth/login` returned **200 with a valid token** — the SPA showed "We could not sign you in." Found during `/check verify` of spec 0011.

**Root cause:** `authSessionSchema.userId` in `frontend/src/lib/auth/session.ts` used `z.uuid()`, which enforces the RFC 4122 version/variant nibbles. The seeded ids are plain .NET GUIDs like `22222222-0000-0000-0000-000000000002` (zero version nibble → valid `Guid`, not a v4 UUID), so `apiFetch` threw at the schema boundary and the healthy 200 was treated as a login failure. Real registered accounts were unaffected (their ids are v4), which is why every green test missed it: the page/flow tests mock the api module, so the wire schema never ran.

## Change

- `session.ts` — `userId` now uses the local `guid` primitive (`lib/api/schemas.ts`), the exact fix the api schemas already carry after the same trap took the quiz list down (spec 0006).
- `profile.schemas.ts` — fixed the **identical second instance** (`profileSchema.userId`), which broke Manage Profile for the same accounts.
- Two new **unmocked** wire-schema tests (`session.test.ts`, `profile.schemas.test.ts`), mirroring the existing `classrooms.schemas.test.ts` / `take.schemas.test.ts` guards (a seeded non-v4 GUID must parse).

These were the last two `z.uuid()` calls on a wire `userId`; form schemas (`z.email()`, `z.url()`) are untouched.

## Verification

- `tsc --noEmit` clean; full frontend suite **172 pass (34 files)**, incl. 7 new tests.
- Live against `docker compose up`: seed student `student@quiztin.dev` now lands on `/dashboard`, and Manage Profile loads as "Sam Carter". No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)